### PR TITLE
Correcting Log method reference so exceptions are properly logged to MEL logger.

### DIFF
--- a/Serilog.Sinks.ILogger/ILoggerSink.cs
+++ b/Serilog.Sinks.ILogger/ILoggerSink.cs
@@ -27,12 +27,12 @@ namespace Serilog.Sinks.ILogger
         {
           formatter.Format(logEvent, stringWriter);
           var message = stringWriter.ToString();
-          logger.Log(logLevel, message, logEvent.Exception, logEvent.Properties);
+          logger.Log(logLevel, logEvent.Exception, message, logEvent.Properties);
         }
       }
       else
       {
-        logger.Log(logLevel, logEvent.RenderMessage(), logEvent.Exception, logEvent.Properties);
+        logger.Log(logLevel, logEvent.Exception, logEvent.RenderMessage(), logEvent.Properties);
       }
     }
   }


### PR DESCRIPTION
I was attempting to use Serilog.Sinks.ILogger in an Azure Function app but was unable to get exceptions logged as expected. Debugging the logger I observed that the following MEL Log method references being used in two locations in `ILoggerSink` ...

`logger.Log(logLevel, message, logEvent.Exception, logEvent.Properties);`

`logger.Log(logLevel, logEvent.RenderMessage(), logEvent.Exception, logEvent.Properties);`

Has the following method signature ...

```
//
// Summary:
//     Formats and writes a log message at the specified log level.
//
// Parameters:
//   logger:
//     The Microsoft.Extensions.Logging.ILogger to write to.
//
//   logLevel:
//     Entry will be written on this level.
//
//   message:
//     Format string of the log message.
//
//   args:
//     An object array that contains zero or more objects to format.
public static void Log(this ILogger logger, LogLevel logLevel, string message, params object[] args);
```

Which results in the `Exception` argument being passed as the first entry to args parameter and the args argument being passed as the second entry to the args parameter. Thus the exception isn't logged to the MEL instance correctly.

This PR changes the aforementioned Log method calls to the following ones by simply flopping the exception and message arguments in accordance with the proper MEL method signature ...

`logger.Log(logLevel, logEvent.Exception, message, logEvent.Properties);`

`logger.Log(logLevel, logEvent.Exception, logEvent.RenderMessage(), logEvent.Properties);`

Which use the following message signature ...

```
//
// Summary:
//     Formats and writes a log message at the specified log level.
//
// Parameters:
//   logger:
//     The Microsoft.Extensions.Logging.ILogger to write to.
//
//   logLevel:
//     Entry will be written on this level.
//
//   exception:
//     The exception to log.
//
//   message:
//     Format string of the log message.
//
//   args:
//     An object array that contains zero or more objects to format.
public static void Log(this ILogger logger, LogLevel logLevel, Exception exception, string message, params object[] args);
```

This way the `Exception` argument is correctly assigned to a `Exception` parameter of MEL instead of the args parameter.
